### PR TITLE
  WP_STRIPE_KEY: Prevent assumed WP_STRIPE_KEY

### DIFF
--- a/includes/stripe-widget-recent.php
+++ b/includes/stripe-widget-recent.php
@@ -5,7 +5,7 @@ class wp_stripe_recent_widget extends WP_Widget {
 	/**
 	* Widget setup.
 	*/
-	function wp_stripe_recent_widget() {
+	function __construct() {
 
 		/* Widget settings. */
 		$widget_ops = array( 'classname' => 'wp-stripe-recent', 'description' => __( 'Display a list of the latest public donations.', 'wp-stripe' ) );
@@ -14,7 +14,7 @@ class wp_stripe_recent_widget extends WP_Widget {
 		$control_ops = array( 'width' => 200, 'height' => 350, 'id_base' => 'wp-stripe-recent' );
 
 		/* Create the widget. */
-		$this->WP_Widget( 'wp-stripe-recent', __( 'WP Stripe - Recent', 'wp-stripe' ), $widget_ops, $control_ops );
+		parent::__construct( 'wp-stripe-recent', __( 'WP Stripe - Recent', 'wp-stripe' ), $widget_ops, $control_ops );
 
 	}
 

--- a/wp-stripe.php
+++ b/wp-stripe.php
@@ -100,7 +100,7 @@ function load_wp_stripe_js() {
 	wp_enqueue_script( 'wp-stripe-js', WP_STRIPE_URL . 'js/wp-stripe.js', array( 'jquery' ), WP_STRIPE_VERSION );
 
 	// Pass some variables to JS
-	wp_localize_script( 'wp-stripe-js', 'wpstripekey', WP_STRIPE_KEY );
+	wp_localize_script( 'wp-stripe-js', 'wpstripekey', (defined('WP_STRIPE_KEY')? WP_STRIPE_KEY : null));
 	wp_localize_script( 'wp-stripe-js', 'ajaxurl', admin_url( 'admin-ajax.php' ) );
 
 }


### PR DESCRIPTION
by checking whether the constant is defined or else giving null.
Fixes #25.

Sadly, PHP constants are annoying like this, they default to strings if not defined, and strings are equivalent to true.
