### PR TITLE
Constructor: Update widget class to php 7/wp 4.4 constructor.

### DIFF
--- a/includes/stripe-widget-recent.php
+++ b/includes/stripe-widget-recent.php
@@ -5,7 +5,7 @@ class wp_stripe_recent_widget extends WP_Widget {
 	/**
 	* Widget setup.
 	*/
-	function wp_stripe_recent_widget() {
+	function __construct() {
 
 		/* Widget settings. */
 		$widget_ops = array( 'classname' => 'wp-stripe-recent', 'description' => __( 'Display a list of the latest public donations.', 'wp-stripe' ) );
@@ -14,7 +14,7 @@ class wp_stripe_recent_widget extends WP_Widget {
 		$control_ops = array( 'width' => 200, 'height' => 350, 'id_base' => 'wp-stripe-recent' );
 
 		/* Create the widget. */
-		$this->WP_Widget( 'wp-stripe-recent', __( 'WP Stripe - Recent', 'wp-stripe' ), $widget_ops, $control_ops );
+		parent::__construct( 'wp-stripe-recent', __( 'WP Stripe - Recent', 'wp-stripe' ), $widget_ops, $control_ops );
 
 	}
 


### PR DESCRIPTION
In wordpress 4.4 the old php 4 style constructors on widgets throw a deprecated message, and in php 7 the old style constructors throw a deprecated notice as well.  Only __construct() is recommended now.  Thus, this commit updates the previous php4 constructor call to use parent::__construct() as within a __construct() method.
